### PR TITLE
feat: add timer with leaderboard

### DIFF
--- a/src/lib/Game.svelte
+++ b/src/lib/Game.svelte
@@ -37,7 +37,7 @@
     let mistakes = 0
     let mistakesThisGuess = 0
     let intervalId: NodeJS.Timeout
-    let timeMs: number
+    let timeMs: number, startTimeMs: number
     let interfaceLoaded = false
     let showMenu: boolean
     let showWinScreen = false
@@ -75,9 +75,9 @@
         else unfoundFeatures = toFind
 
         clearInterval(intervalId)
-        const startTime = Date.now()
+        startTimeMs = Date.now()
         intervalId = setInterval(() => {
-            timeMs = Date.now() - startTime
+            timeMs = Date.now() - startTimeMs
         }, 1000)
 
         questionFeature = undefined
@@ -94,9 +94,9 @@
         originalToFind = toFind
 
         clearInterval(intervalId)
-        const startTime = Date.now()
+        startTimeMs = Date.now()
         intervalId = setInterval(() => {
-            timeMs = Date.now() - startTime
+            timeMs = Date.now() - startTimeMs
 
             if (configuration?.mode === 'dailyQuest') {
                 $save.dailyQuestProgress = {...$save.dailyQuestProgress, timeMs: timeMs}
@@ -202,7 +202,13 @@
             if (toFind.length === 0) {
                 clearInterval(intervalId)
 
-                const leaderboardEntry: LeaderboardEntry = {total: originalToFind.length, correct: correct + 1 /* correct counter hasnt't yet updated */, timeMs, createdAt: Date.now()}
+                timeMs = Date.now() - startTimeMs
+                const leaderboardEntry: LeaderboardEntry = {
+                    total: originalToFind.length,
+                    correct: correct + 1 /* correct counter hasnt't yet updated */,
+                    timeMs,
+                    createdAt: Date.now()
+                }
                 saveToLeaderboard(leaderboardEntry)
 
                 showMenu = true

--- a/src/lib/Game.svelte
+++ b/src/lib/Game.svelte
@@ -195,6 +195,15 @@
             if (toFind.length === 0) {
                 clearInterval(intervalId)
 
+                const currentQuestId = `${chosenMap.id}-${gameConfiguration.countries}`
+                const currentQuestLeaderboard = $save.localLeaderboard[currentQuestId]
+                const leaderboardEntry = {total: originalToFind.length, correct: correct + 1 /* correct counter hasnt't yet updated */, timeMs, createdAt: Date.now()}
+                if (!currentQuestLeaderboard) {
+                    $save.localLeaderboard[currentQuestId] = [leaderboardEntry]
+                } else {
+                    $save.localLeaderboard[currentQuestId] = [...currentQuestLeaderboard, leaderboardEntry]
+                }
+
                 showMenu = true
                 showWinScreen = true
                 focusedCountry = undefined

--- a/src/lib/Game.svelte
+++ b/src/lib/Game.svelte
@@ -201,7 +201,11 @@
                 if (!currentQuestLeaderboard) {
                     $save.localLeaderboard[currentQuestId] = [leaderboardEntry]
                 } else {
-                    $save.localLeaderboard[currentQuestId] = [...currentQuestLeaderboard, leaderboardEntry]
+                    const place = currentQuestLeaderboard.findIndex(entry => entry.timeMs >= timeMs)
+                    if (place !== -1) {
+                        currentQuestLeaderboard.splice(place, 0, leaderboardEntry)
+                        $save.localLeaderboard[currentQuestId] = currentQuestLeaderboard.slice(0, 10)
+                    }
                 }
 
                 showMenu = true

--- a/src/lib/icons/IconTimer.svelte
+++ b/src/lib/icons/IconTimer.svelte
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+    ><line x1="10" x2="14" y1="2" y2="2" /><line x1="12" x2="15" y1="14" y2="11" /><circle cx="12" cy="14" r="9" /></svg
+>

--- a/src/lib/map/Map.svelte
+++ b/src/lib/map/Map.svelte
@@ -12,7 +12,7 @@
     let transform = d3.zoomIdentity
     $: d3Svg && ($noPanNoZoom ? disableZoom() : enableZoom())
     function disableZoom() {
-        d3Svg.call(zoom).on('mousedown.zoom', null).on('touchstart.zoom', null).on('touchmove.zoom', null).on('touchend.zoom', null).on('dblclick.zoom', null)
+        d3Svg.call(zoom).on('.zoom', null)
     }
     function enableZoom() {
         d3Svg.call(zoom)

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -114,15 +114,17 @@ export const timeLeft = derived(time, $time => {
 export const showDebug = writable(false)
 
 // Save files
-export const initialSave = {achievements: [], dailyQuestProgress: {}}
-export const save = localStorageWritable('save', initialSave)
+export const initialSave = {achievements: [], dailyQuestProgress: {}, localLeaderboard: {}}
+export const save = localStorageWritable('save', initialSave, initialSave)
 
 // Utils
-function localStorageWritable(key: string, initial: unknown) {
+function localStorageWritable(key: string, initial: unknown, defaultValue?: object) {
     let savedValue
 
     try {
-        savedValue = browser ? JSON.parse(window.localStorage.getItem(key) || 'null') ?? initial : initial
+        const parsedLocalStorageItem = JSON.parse(window.localStorage.getItem(key) || 'null')
+        const parsedItemWithDefault = defaultValue ? {...defaultValue, ...parsedLocalStorageItem} : parsedLocalStorageItem
+        savedValue = browser ? parsedItemWithDefault ?? initial : initial
     } catch (err) {
         console.error(err)
     }

--- a/src/lib/translations/de/ui.json
+++ b/src/lib/translations/de/ui.json
@@ -12,5 +12,6 @@
     "share": "Teilen",
     "start": "Start",
     "flagsOnly": "Zeige nur Flaggen",
-    "noPanNoZoom": "Schwenken und Zoomen deaktivieren"
+    "noPanNoZoom": "Schwenken und Zoomen deaktivieren",
+    "leaderboard": "Bestenliste"
 }

--- a/src/lib/translations/de/ui.json
+++ b/src/lib/translations/de/ui.json
@@ -13,5 +13,6 @@
     "start": "Start",
     "flagsOnly": "Zeige nur Flaggen",
     "noPanNoZoom": "Schwenken und Zoomen deaktivieren",
-    "leaderboard": "Bestenliste"
+    "leaderboard": "Bestenliste",
+    "newBest": "Neues Bestes!"
 }

--- a/src/lib/translations/en/ui.json
+++ b/src/lib/translations/en/ui.json
@@ -13,5 +13,6 @@
     "share": "Share",
     "start": "Start",
     "flagsOnly": "Display Flag Only",
-    "noPanNoZoom": "Disable pan and zoom"
+    "noPanNoZoom": "Disable pan and zoom",
+    "leaderboard": "Leaderboard"
 }

--- a/src/lib/translations/en/ui.json
+++ b/src/lib/translations/en/ui.json
@@ -14,5 +14,6 @@
     "start": "Start",
     "flagsOnly": "Display Flag Only",
     "noPanNoZoom": "Disable pan and zoom",
-    "leaderboard": "Leaderboard"
+    "leaderboard": "Leaderboard",
+    "newBest": "New best!"
 }

--- a/src/lib/translations/es/ui.json
+++ b/src/lib/translations/es/ui.json
@@ -12,5 +12,6 @@
     "share": "Compartir",
     "start": "Comenzar",
     "flagsOnly": "Mostrar solo banderas",
-    "noPanNoZoom": "Desactivar la panorámica y el zoom"
+    "noPanNoZoom": "Desactivar la panorámica y el zoom",
+    "leaderboard": "Tabla de clasificación"
 }

--- a/src/lib/translations/es/ui.json
+++ b/src/lib/translations/es/ui.json
@@ -13,5 +13,6 @@
     "start": "Comenzar",
     "flagsOnly": "Mostrar solo banderas",
     "noPanNoZoom": "Desactivar la panorámica y el zoom",
-    "leaderboard": "Tabla de clasificación"
+    "leaderboard": "Tabla de clasificación",
+    "newBest": "¡Nuevo mejor!"
 }

--- a/src/lib/ui/UI.svelte
+++ b/src/lib/ui/UI.svelte
@@ -14,13 +14,14 @@
     import BuyMeACoffee from '$lib/ui/BuyMeACoffee.svelte'
     import Menu from '$lib/ui/menu/Menu.svelte'
     import Notifications from '$lib/ui/Notifications.svelte'
-    import {achieveAchievement} from '$lib/utils'
+    import {achieveAchievement, getTimeStringFromMs} from '$lib/utils'
     import IconLock from '$lib/icons/IconLock.svelte'
 
     export let foundFeatures
     export let originalToFind
     export let questionFeature
     export let streak
+    export let timeMs
     export let restart
     export let showMenu = false
     export let mistakes
@@ -79,6 +80,12 @@
                         <IconCheckmark />
                         {#key correct}
                             <span in:scale|global={{start: 1.5}} class="ml-1">{correct}</span>
+                        {/key}
+                    </span>
+                    <span class="flex items-center justify-center mx-2 text-foreground">
+                        <IconCheckmark />
+                        {#key timeMs}
+                            <span in:scale|global={{start: 1.5}} class="ml-1">{getTimeStringFromMs(timeMs)}</span>
                         {/key}
                     </span>
                     <span class="mx-5 whitespace-nowrap">{foundFeatures.length} / {originalToFind.length}</span>

--- a/src/lib/ui/UI.svelte
+++ b/src/lib/ui/UI.svelte
@@ -16,6 +16,7 @@
     import Notifications from '$lib/ui/Notifications.svelte'
     import {achieveAchievement, getTimeStringFromMs} from '$lib/utils'
     import IconLock from '$lib/icons/IconLock.svelte'
+    import IconTimer from '$lib/icons/IconTimer.svelte'
 
     export let foundFeatures
     export let originalToFind
@@ -83,9 +84,9 @@
                         {/key}
                     </span>
                     <span class="flex items-center justify-center mx-2 text-foreground">
-                        <IconCheckmark />
+                        <IconTimer />
                         {#key timeMs}
-                            <span in:scale|global={{start: 1.5}} class="ml-1">{getTimeStringFromMs(timeMs)}</span>
+                            <span class="ml-1">{getTimeStringFromMs(timeMs)}</span>
                         {/key}
                     </span>
                     <span class="mx-5 whitespace-nowrap">{foundFeatures.length} / {originalToFind.length}</span>

--- a/src/lib/ui/menu/Leaderboard.svelte
+++ b/src/lib/ui/menu/Leaderboard.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    import {chosenMap, save} from '$lib/store'
+    import {getTimeStringFromMs} from '$lib/utils'
+
+    export let gameConfiguration
+
+    const hasTimeMs = (value: unknown): value is {timeMs: number} => typeof value === 'object' && value !== null && 'timeMs' in value && typeof value.timeMs === 'number'
+
+    const leaderboardEntries = $save.localLeaderboard[`${chosenMap.id}-${gameConfiguration.countries}`]?.sort((a: unknown, b: unknown) => hasTimeMs(a) && hasTimeMs(b) && a.timeMs - b.timeMs) ?? []
+</script>
+
+<ol role="list">
+    {#each leaderboardEntries as entry, i}
+        <li class="flex px-8 py-2 mb-2 text-xl text-black rounded-md bg-foreground-light">
+            <span class="opacity-50 mr-2">{i + 1}.</span>
+            <span class="grow">{getTimeStringFromMs(entry.timeMs)}</span>
+            <span class="">{entry.correct}/{entry.total}</span>
+        </li>
+    {:else}
+        <li class="text-center font-bold mb-8">No leaderboard entries</li>
+    {/each}
+</ol>

--- a/src/lib/ui/menu/Leaderboard.svelte
+++ b/src/lib/ui/menu/Leaderboard.svelte
@@ -4,9 +4,7 @@
 
     export let gameConfiguration
 
-    const hasTimeMs = (value: unknown): value is {timeMs: number} => typeof value === 'object' && value !== null && 'timeMs' in value && typeof value.timeMs === 'number'
-
-    const leaderboardEntries = $save.localLeaderboard[`${chosenMap.id}-${gameConfiguration.countries}`]?.sort((a: unknown, b: unknown) => hasTimeMs(a) && hasTimeMs(b) && a.timeMs - b.timeMs) ?? []
+    const leaderboardEntries = $save.localLeaderboard[`${chosenMap.id}-${gameConfiguration.countries}`] ?? []
 </script>
 
 <ol role="list">

--- a/src/lib/ui/menu/Leaderboard.svelte
+++ b/src/lib/ui/menu/Leaderboard.svelte
@@ -11,7 +11,7 @@
     {#each leaderboardEntries as entry, i}
         <li class="flex px-8 py-2 mb-2 text-xl text-black rounded-md bg-foreground-light">
             <span class="opacity-50 mr-2">{i + 1}.</span>
-            <span class="grow">{getTimeStringFromMs(entry.timeMs)}</span>
+            <span class="grow">{getTimeStringFromMs(entry.timeMs, true)}</span>
             <span class="">{entry.correct}/{entry.total}</span>
         </li>
     {:else}

--- a/src/lib/ui/menu/Leaderboard.svelte
+++ b/src/lib/ui/menu/Leaderboard.svelte
@@ -4,7 +4,7 @@
 
     export let gameConfiguration
 
-    const leaderboardEntries = $save.localLeaderboard[`${chosenMap.id}-${gameConfiguration.countries}`] ?? []
+    $: leaderboardEntries = $save.localLeaderboard[`${chosenMap.id}-${gameConfiguration.countries}`] ?? []
 </script>
 
 <ol role="list">

--- a/src/lib/ui/menu/MainMenu.svelte
+++ b/src/lib/ui/menu/MainMenu.svelte
@@ -12,8 +12,10 @@
     import SettingsMenu from '$lib/ui/menu/SettingsMenu.svelte'
     import SwitchQuestMenu from '$lib/ui/menu/SwitchQuestMenu.svelte'
     import WinScreen from '$lib/ui/menu/WinScreen.svelte'
+    import Leaderboard from './Leaderboard.svelte'
 
     export let restart
+    export let gameConfiguration
     export let toggleMenu
     export let showWinScreen
     export let newDailyQuest
@@ -24,7 +26,7 @@
 </script>
 
 {#if showWinScreen}
-    <WinScreen {...$$restProps} />
+    <WinScreen {gameConfiguration} {...$$restProps} />
 {/if}
 
 <div class="flex flex-col">
@@ -63,6 +65,9 @@
         class="p-2 mb-2 text-xl text-black uppercase rounded-md bg-foreground-light hover:bg-background hover:text-foreground disabled:opacity-30 disabled:hover:bg-foreground disabled:hover:text-background"
     >
         {$t('ui.restart')}
+    </button>
+    <button on:click={() => setActiveMenu(Leaderboard)} class="p-2 mb-2 text-xl uppercase text-black rounded-md bg-foreground-light hover:bg-background hover:text-foreground">
+        {$t('ui.leaderboard')}
     </button>
     <div class="flex items-center justify-between mt-3">
         <button on:click={() => setActiveMenu(AboutMenu)} class="p-2 rounded-full cursor-pointer bg-foreground-light text-background hover:bg-background hover:text-foreground">

--- a/src/lib/ui/menu/Menu.svelte
+++ b/src/lib/ui/menu/Menu.svelte
@@ -11,6 +11,7 @@
     export let toggleMenu
     export let gameConfiguration
     export let timeMs
+    export let showWinScreen
 
     let activeMenu = MainMenu
 
@@ -41,7 +42,7 @@
             out:fly|global={{y: 5, duration: 100}}
             class="relative inline-block w-full text-left align-bottom transition-all transform rounded-lg shadow-xl bg-gradient-to-br from-green outline outline-8 outline-background text-background bg-foreground sm:my-8 sm:align-middle sm:max-w-lg"
         >
-            {#if isNewBest && activeMenu === MainMenu}
+            {#if isNewBest && showWinScreen && activeMenu === MainMenu}
                 <div class="absolute z-20 -top-8 -left-8 -rotate-12 flex items-center gap-2 px-4 py-2 w-fit rounded-md bg-background text-yellow" in:fly|global={{y: 20, duration: 500}}>
                     <IconTrophy />
                     <p class="text-xl font-medium">{$t('ui.newBest')}</p>

--- a/src/lib/ui/menu/Menu.svelte
+++ b/src/lib/ui/menu/Menu.svelte
@@ -4,14 +4,23 @@
     import IconArrowLeft from '$lib/icons/IconArrowLeft.svelte'
     import IconClose from '$lib/icons/IconClose.svelte'
     import MainMenu from '$lib/ui/menu/MainMenu.svelte'
+    import {chosenMap, save} from '$lib/store'
+    import IconTrophy from '$lib/icons/IconTrophy.svelte'
 
     export let toggleMenu
+    export let gameConfiguration
+    export let timeMs
 
     let activeMenu = MainMenu
 
     function setActiveMenu(screen) {
         activeMenu = screen
     }
+
+    // TODO: maybe create a function getLocalLeaderboardEntries
+    // we can't show it for daily quests because every time you reload it will show "new best", which is kinda weird
+    $: leaderboardEntries = gameConfiguration.mode === 'dailyQuest' ? [] : $save.localLeaderboard[`${chosenMap.id}-${gameConfiguration.countries}`] ?? []
+    $: isNewBest = leaderboardEntries.length === 1 || (leaderboardEntries.length > 1 && leaderboardEntries[1 /* prev */].timeMs > timeMs) // curr. could get from leaderboardEntries, but no need
 </script>
 
 <div class="fixed inset-0 z-50 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
@@ -25,11 +34,18 @@
         />
         <!-- This element is to trick the browser into centering the modal contents. -->
         <span class="hidden select-none sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+        <!-- overflow-hidden was removed to add popover with "new best!" above. nothing will break, right? right?.. --->
         <div
             in:fly|global={{y: 15, duration: 400}}
             out:fly|global={{y: 5, duration: 100}}
-            class="inline-block w-full overflow-hidden text-left align-bottom transition-all transform rounded-lg shadow-xl bg-gradient-to-br from-green outline outline-8 outline-background text-background bg-foreground sm:my-8 sm:align-middle sm:max-w-lg"
+            class="relative inline-block w-full text-left align-bottom transition-all transform rounded-lg shadow-xl bg-gradient-to-br from-green outline outline-8 outline-background text-background bg-foreground sm:my-8 sm:align-middle sm:max-w-lg"
         >
+            {#if isNewBest && activeMenu === MainMenu}
+                <div class="absolute z-20 -top-8 -left-8 -rotate-12 flex items-center gap-2 px-4 py-2 w-fit rounded-md bg-background text-yellow" in:fly|global={{y: 20, duration: 500}}>
+                    <IconTrophy />
+                    <p class="text-xl font-medium">new best!</p>
+                </div>
+            {/if}
             <div class="flex flex-col p-5">
                 <div class="flex justify-between mb-4">
                     {#if activeMenu !== MainMenu}

--- a/src/lib/ui/menu/Menu.svelte
+++ b/src/lib/ui/menu/Menu.svelte
@@ -6,6 +6,7 @@
     import MainMenu from '$lib/ui/menu/MainMenu.svelte'
     import {chosenMap, save} from '$lib/store'
     import IconTrophy from '$lib/icons/IconTrophy.svelte'
+    import {t} from '$lib/translations'
 
     export let toggleMenu
     export let gameConfiguration
@@ -43,7 +44,7 @@
             {#if isNewBest && activeMenu === MainMenu}
                 <div class="absolute z-20 -top-8 -left-8 -rotate-12 flex items-center gap-2 px-4 py-2 w-fit rounded-md bg-background text-yellow" in:fly|global={{y: 20, duration: 500}}>
                     <IconTrophy />
-                    <p class="text-xl font-medium">new best!</p>
+                    <p class="text-xl font-medium">{$t('ui.newBest')}</p>
                 </div>
             {/if}
             <div class="flex flex-col p-5">

--- a/src/lib/ui/menu/WinScreen.svelte
+++ b/src/lib/ui/menu/WinScreen.svelte
@@ -58,7 +58,7 @@
             <span in:fly|global={{x: -10, delay: 1200}} class="flex items-center justify-start text-foreground">
                 <IconMistake />
                 <span class="ml-1">
-                    {getTimeStringFromMs(timeMs)}
+                    {getTimeStringFromMs(timeMs, true)}
                 </span>
             </span>
         </div>

--- a/src/lib/ui/menu/WinScreen.svelte
+++ b/src/lib/ui/menu/WinScreen.svelte
@@ -8,6 +8,7 @@
     import {save} from '$lib/store'
     import {t} from '$lib/translations'
     import {getTimeStringFromMs} from '$lib/utils'
+    import IconTimer from '$lib/icons/IconTimer.svelte'
 
     export let mistakes: number
     export let correct: number
@@ -56,7 +57,7 @@
                 {/if}
             </span>
             <span in:fly|global={{x: -10, delay: 1200}} class="flex items-center justify-start text-foreground">
-                <IconMistake />
+                <IconTimer />
                 <span class="ml-1">
                     {getTimeStringFromMs(timeMs, true)}
                 </span>

--- a/src/lib/ui/menu/WinScreen.svelte
+++ b/src/lib/ui/menu/WinScreen.svelte
@@ -7,9 +7,11 @@
     import IconShare from '$lib/icons/IconShare.svelte'
     import {save} from '$lib/store'
     import {t} from '$lib/translations'
+    import {getTimeStringFromMs} from '$lib/utils'
 
     export let mistakes: number
     export let correct: number
+    export let timeMs: number
     export let originalToFind: unknown[]
     export let gameConfiguration
 
@@ -52,6 +54,12 @@
                 {:else}
                     <span class="ml-1">{$t('ui.correctAnswers', {correct, allAnswers: originalToFind.length})}</span>
                 {/if}
+            </span>
+            <span in:fly|global={{x: -10, delay: 1200}} class="flex items-center justify-start text-foreground">
+                <IconMistake />
+                <span class="ml-1">
+                    {getTimeStringFromMs(timeMs)}
+                </span>
             </span>
         </div>
     </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -91,10 +91,10 @@ export function processExtraAchievements(features, questId) {
     }
 }
 
-export function getTimeStringFromMs(timeMs: number): string {
-    return `${formatTime(timeMs / 1000 / 60)}:${formatTime((timeMs / 1000) % 60)}`
+export function getTimeStringFromMs(timeMs: number, withMs?: boolean): string {
+    return `${formatTimeUnit(Math.floor(timeMs / 1000 / 60))}:${formatTimeUnit(Math.floor((timeMs / 1000) % 60))}${withMs ? '.' + (timeMs % 1000) : ''}`
 }
 
-function formatTime(time: number): string {
-    return String(Math.round(time)).padStart(2, '0')
+function formatTimeUnit(time: number): string {
+    return String(time).padStart(2, '0')
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -90,3 +90,11 @@ export function processExtraAchievements(features, questId) {
         if (questId == achievement.quest && _.difference(getFeaturesFromTags(achievement.extra.tags), features).length === 0) achieveAchievement(achievement.slug)
     }
 }
+
+export function getTimeStringFromMs(timeMs: number): string {
+    return `${formatTime(timeMs / 1000 / 60)}:${formatTime((timeMs / 1000) % 60)}`
+}
+
+function formatTime(time: number): string {
+    return String(Math.round(time)).padStart(2, '0')
+}


### PR DESCRIPTION
## Changes

- disable all all zoom events when `noPanNoZoom` is true, including mouse wheel zoom
- add timer with minutes and seconds between `correct answers` and `correct answers` / `all answers`
- add `localLeaderboard` *(just realized should probably be renamed to `localLeaderboards`)* to `save` key in localStorage
- add `New best!` popover when got a new record
- add `Leaderboard` button below  `Restart`
- add `Leaderboard` menu with all times and correct out of all answers